### PR TITLE
Add MD5 calculation progress tracking and caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ venv/
 .idea/
 .vscode/
 .cursor/
+*.sh
+lfs-server
+performance_test.md


### PR DESCRIPTION
- Introduced a new endpoint to retrieve MD5 calculation progress.
- Implemented an MD5 cache to store results and manage concurrent calculations.
- Updated file handlers to include the new progress endpoint and modified existing MD5 retrieval logic to utilize caching.
- Enhanced the .gitignore to exclude additional files.